### PR TITLE
feat(cli): add --quiet option for streamlined output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Test CLI signing functionality
         run: |
           echo "🔐 Testing CLI signing functionality..."
-          RESULT=$(node dist/cli.cjs sign --key-file test-build-key.key --params test-build-params.json)
+          RESULT=$(node dist/cli.cjs sign --key-file test-build-key.key --params test-build-params.json --quiet)
           echo "Signing result: $RESULT"
           if [[ $RESULT =~ ^0x[0-9a-fA-F]+$ ]]; then
             echo "✅ CLI signing test passed"

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -100,6 +100,7 @@ program
   .option('-p, --params <path>', 'トランザクションパラメータが含まれるJSONファイルへのパス。')
   .option('--broadcast', 'トランザクションをネットワークにブロードキャストします。')
   .option('--rpc-url <url>', 'カスタムRPCエンドポイントのURL。')
+  .option('-q, --quiet', '署名済みトランザクションデータまたはトランザクションハッシュのみ出力します。')
   .allowUnknownOption(false)
   .action(
     /**
@@ -112,6 +113,7 @@ program
       params?: string;
       broadcast?: boolean;
       rpcUrl?: string;
+      quiet?: boolean;
     }) => {
       try {
         // core層の唯一の窓口であるrunCliを呼び出す

--- a/src/core/nonceRetry.ts
+++ b/src/core/nonceRetry.ts
@@ -14,6 +14,7 @@ export interface Logger {
   info(message: string): void;
   error(message: string): void;
   warn(message: string): void;
+  data(message: string): void;
 }
 
 /**

--- a/src/core/transactionProcessor.ts
+++ b/src/core/transactionProcessor.ts
@@ -24,6 +24,7 @@ export interface Logger {
   info(message: string): void;
   warn(message: string): void;
   error(message: string): void;
+  data(message: string): void;
 }
 
 /**
@@ -278,7 +279,7 @@ export async function processTransaction(
     privateKey as `0x${string}`,
     txParams
   );
-  userLogger.info(`✅ 署名完了: ${signedTransaction}`);
+  userLogger.info(`✅ 署名完了`);
 
   // 2. ブロードキャスト処理（オプション）
   if (!broadcast) {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -128,6 +128,7 @@ export const LoggerSchema = z.object({
   info: z.function().args(z.string()).returns(z.void()),
   warn: z.function().args(z.string()).returns(z.void()),
   error: z.function().args(z.string()).returns(z.void()),
+  data: z.function().args(z.string()).returns(z.void()),
 });
 
 /**
@@ -182,6 +183,7 @@ export const CliOptionsSchema = z
       ),
     broadcast: z.boolean().default(false),
     rpcUrl: z.string().url('有効なRPCエンドポイントのURLを指定してください。').optional(),
+    quiet: z.boolean().default(false),
   })
   .refine((data) => !data.broadcast || data.rpcUrl !== undefined, {
     message:

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,39 +1,63 @@
 /**
- * 🔧 ロガーシステム
- * 本番環境では通常出力する
- */
-
-/**
  * ロガーインターフェース
  */
 export interface Logger {
   info: (message: string) => void;
   warn: (message: string) => void;
   error: (message: string) => void;
+  data: (message: string) => void;
 }
 
 /**
- * ロガー（標準コンソール出力）
+ * ロガー（本番環境の通常出力用）
+ * @description 全ての補助情報はstderrに出力し、データ出力のみstdoutに出力
  */
 const productionLogger: Logger = {
-  info: (message: string) => console.info(message),
+  info: (message: string) => console.error(message),
   warn: (message: string) => console.warn(message),
   error: (message: string) => console.error(message),
+  data: (message: string) => console.log(message),
 };
 
 /**
- * 現在の環境に適したロガーインスタンス
+ * ロガー（Quietモード用）
+ * @description ログは抑制し、データ出力とエラーのみ行う
+ */
+const quietLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: (message: string) => console.error(message),
+  data: (message: string) => console.log(message),
+};
+
+/**
+ * オプションに応じて適切なロガーを生成するファクトリ関数
+ * @param options コマンドラインから受け取ったオプション
+ * @returns 適切なロガーインスタンス
+ * @description quietモードの判定ロジックをロガー生成時に集約
+ */
+export function createLogger(options: { quiet?: boolean }): Logger {
+  if (options.quiet) {
+    return quietLogger;
+  }
+  return productionLogger;
+}
+
+/**
+ * デフォルトロガーインスタンス
+ * @description 既存コードとの互換性を保ちつつ、新しいファクトリ関数への移行を促進
  */
 export const logger: Logger = productionLogger;
 
 /**
  * テスト用のロガーオーバーライド機能
- * テストでlogger出力をスパイする場合に使用
+ * @description テストでlogger出力をスパイする場合に使用
  */
 export function createTestLogger(): Logger {
   return {
     info: () => {},
     warn: () => {},
     error: () => {},
+    data: () => {},
   };
 }


### PR DESCRIPTION
## Changes
- add a `--quiet` (`-q`) command-line option to suppress informational logs
- implement a `createLogger` factory to provide either a standard or a quiet logger
- inject the logger instance throughout the core application logic
- update `LoggerSchema` to include the `data` method for type safety

## Technical Details
- use dependency injection for the logger to improve testability and separate concerns between logging and business logic
- create a `quietLogger` that only outputs final data (via `data`) and errors, while suppressing progress messages (`info`, `warn`)
- modify the main application entry point to use the `createLogger` factory, ensuring the correct logger is used based on user input
- refactor core functions (`processTransactions`, `executeWithNonceRetry`) to accept a logger instance, decoupling them from a global logger