### PR TITLE
 test: Introduce quiet mode for cleaner CLI output

### DIFF
--- a/test/unit/core/app.test.ts
+++ b/test/unit/core/app.test.ts
@@ -37,18 +37,18 @@ describe('app.ts', () => {
   beforeAll(async () => {
     ({ runCli } = await import('../../../src/core/app.js'));
   });
-  let mockConsoleInfo: ReturnType<typeof vi.fn>;
-  let originalConsoleInfo: typeof console.info;
+  let mockConsoleError: ReturnType<typeof vi.fn>;
+  let originalConsoleError: typeof console.error;
 
   beforeEach(() => {
-    originalConsoleInfo = console.info;
-    mockConsoleInfo = vi.fn();
-    console.info = mockConsoleInfo;
+    originalConsoleError = console.error;
+    mockConsoleError = vi.fn();
+    console.error = mockConsoleError;
     vi.clearAllMocks();
   });
 
   afterEach(() => {
-    console.info = originalConsoleInfo;
+    console.error = originalConsoleError;
   });
 
   describe('loadTransactionParams', () => {
@@ -154,7 +154,7 @@ describe('app.ts', () => {
       await runCli(validOptions);
 
       expect(mockGetDisplayNetworkInfo).toHaveBeenCalledWith(1);
-      expect(mockConsoleInfo).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining('🌐 検出されたネットワーク: Ethereum Mainnet')
       );
     });
@@ -194,7 +194,7 @@ describe('app.ts', () => {
 
       await runCli(validOptions);
 
-      expect(mockConsoleInfo).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining(
           '⚠️  カスタムネットワークです。ブロードキャスト先が正しいことを確認してください。'
         )

--- a/test/unit/core/nonceRetry.test.ts
+++ b/test/unit/core/nonceRetry.test.ts
@@ -29,6 +29,7 @@ describe('nonceRetry', () => {
     info: vi.fn(),
     error: vi.fn(),
     warn: vi.fn(),
+    data: vi.fn(),
   };
 
   beforeEach(() => {

--- a/test/unit/types/schema.test.ts
+++ b/test/unit/types/schema.test.ts
@@ -823,7 +823,7 @@ describe('Internal Schema Completeness Tests', () => {
 
   describe('LoggerSchema', () => {
     it('should accept valid logger object', () => {
-      const logger = { info: () => {}, warn: () => {}, error: () => {} };
+      const logger = { info: () => {}, warn: () => {}, error: () => {}, data: () => {} };
       expect(LoggerSchema.safeParse(logger).success).toBe(true);
     });
     it('should reject missing methods', () => {


### PR DESCRIPTION
## Changes
- Introduces a `--quiet` CLI option to suppress informational and warning messages.
- This provides cleaner output, making the tool easier to use in scripts and CI/CD pipelines.
- The primary result (e.g., transaction hash) is now the only output to standard output in quiet mode.
- All non-essential logs are now consistently directed to standard error.

## Technical Details
- Implemented a `createLogger` factory to generate either a standard or "quiet" logger instance.
- Added a `logger.data()` method that exclusively writes to `stdout` for scriptable output.
- Redirected all `logger.info()` calls to `console.error` to keep `stdout` clean for the data output.
- Updated all relevant tests (`app`, `transactionProcessor`, `nonceRetry`) to use and verify the new logger.